### PR TITLE
Remove TacTalk as it's not NLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Bitext alignment is the process of aligning two parallel documents on a segment 
 
 * [chatterbot](https://github.com/muffinista/chatterbot) - A straightforward ruby-based Twitter Bot Framework, using OAuth to authenticate
 * [Lita](https://github.com/jimmycuadra/lita) - Lita is a chat bot written in Ruby with persistent storage provided by Redis
-* [Tactalk](https://github.com/tacnoman/tactalk) - gem to make a chatterbot using ruby
 
 ## Classification
 


### PR DESCRIPTION
Since TacTalk seems to be a WIP and contains only `fuzzy_search` for now. Other gems aren't really used.

BTW: Maybe removing isn't the best thing, but adding a note would definitely be good, since just matching based on similarity isn't NLP, at all.
